### PR TITLE
Move ecmaFeatures key under parserOptions in legacy file

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -13,7 +13,9 @@ module.exports = {
     mocha: false,
     jasmine: false
   },
-  ecmaFeatures: {},
+  parserOptions: {
+    ecmaFeatures: {}
+  },
   globals: {},
   rules: {}
 };


### PR DESCRIPTION
This was causing an error with eslint 4.1